### PR TITLE
Jinja template filters

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 anyhow = "1.0.95"
 clap = { version = "4.5.26", features = ["derive", "string"] }
 git2 = "0.20.0"
-minijinja = { version = "2.6.0", features = ["loader"] }
+minijinja = { version = "2.6.0", features = ["builtins", "loader"] }
 serde = { version = "1.0.217", features = ["derive"] }
 serde_json = "1.0.135"
 sysinfo = "0.33.1"

--- a/src/config/output/filters.rs
+++ b/src/config/output/filters.rs
@@ -1,0 +1,44 @@
+// Filters need arguments passed by value.
+#![allow(clippy::needless_pass_by_value)]
+use std::time::Duration;
+
+use minijinja::{value::ViaDeserialize, Environment};
+
+/// Compute an average over a slice of floating point numbers.
+fn average(values: Vec<f64>) -> f64 {
+    if values.is_empty() {
+        return 0.0;
+    }
+    #[allow(clippy::cast_precision_loss)]
+    let count = values.len() as f64;
+    values.into_iter().sum::<f64>() / count
+}
+
+/// Convert bytes to kibibytes.
+fn bytes_to_kb(value: f64) -> f64 {
+    value / 1024.0
+}
+
+/// Convert bytes to mibibytes.
+fn bytes_to_mb(value: f64) -> f64 {
+    value / (1024.0 * 1024.0)
+}
+
+/// Get number of milliseconds in a Duration.
+fn as_millis(value: ViaDeserialize<Duration>) -> u128 {
+    value.as_millis()
+}
+
+/// Get number of seconds in a Duration.
+fn as_secs(value: ViaDeserialize<Duration>) -> f64 {
+    value.as_secs_f64()
+}
+
+/// Add all custom filters to a templating engine.
+pub(super) fn add_filters_to_engine(engine: &mut Environment) {
+    engine.add_filter("avg", average);
+    engine.add_filter("as_millis", as_millis);
+    engine.add_filter("as_secs", as_secs);
+    engine.add_filter("as_kb", bytes_to_kb);
+    engine.add_filter("as_mb", bytes_to_mb);
+}

--- a/src/config/output/tests.rs
+++ b/src/config/output/tests.rs
@@ -6,17 +6,20 @@ mod template {
 
     use super::Formatter;
 
+    fn test_output(template: &str, results: Results, expected: &str) {
+        let formatter = Formatter::from_template_string(template.to_string()).unwrap();
+        let rendered_results = formatter.render_results(results).unwrap();
+        assert_eq!(rendered_results, expected.to_string());
+    }
+
     #[test]
     fn trivial() {
-        let template = "No output!".to_string();
-        let formatter = Formatter::from_template_string(template.clone()).unwrap();
-        let rendered_results = formatter.render_results(Results::default()).unwrap();
-        assert_eq!(rendered_results, template);
+        test_output("No output", Results::default(), "No output");
     }
 
     #[test]
     fn undefined_values() {
-        let template = "I'm a {{ bad_value }} with {{ avg_cpu }}".to_string();
+        let template = "I'm a {{ bad_value }} with {{ cpu | min }} CPU usage".to_string();
         let formatter = Formatter::from_template_string(template);
         let expected_error =
             r#"Template validation failed. Undefined variables used: ["bad_value"]."#.to_string();
@@ -27,10 +30,62 @@ mod template {
 
     #[test]
     fn nested_values() {
-        let template = "Ran in {{ wall_time.secs }} whole seconds".to_string();
-        let formatter = Formatter::from_template_string(template).unwrap();
-        let rendered_results = formatter.render_results(Results::default()).unwrap();
-        let expected_results = "Ran in 0 whole seconds".to_string();
-        assert_eq!(rendered_results, expected_results);
+        test_output(
+            "Ran in {{ wall_time.secs }} whole seconds",
+            Results::default(),
+            "Ran in 0 whole seconds",
+        );
+    }
+
+    mod filters {
+        use super::{test_output, Results};
+
+        #[test]
+        fn jinja_filters() {
+            test_output(
+                "Min CPU usage: {{ cpu | min }}",
+                Results {
+                    cpu: vec![30.0, 50.0, 10.0, 40.0],
+                    ..Results::default()
+                },
+                "Min CPU usage: 10.0",
+            );
+        }
+
+        #[test]
+        fn custom_cpu_filters() {
+            test_output(
+                "Avg CPU usage: {{ cpu | avg }}",
+                Results {
+                    cpu: vec![30.0, 10.0],
+                    ..Results::default()
+                },
+                "Avg CPU usage: 20.0",
+            );
+        }
+
+        #[test]
+        fn custom_ram_filters() {
+            test_output(
+                "avg kb: {{ ram | avg | as_kb }}",
+                Results {
+                    ram: vec![1024.0, 2048.0],
+                    ..Results::default()
+                },
+                "avg kb: 1.5",
+            );
+        }
+
+        #[test]
+        fn custom_time_filters() {
+            test_output(
+                "millis: {{ wall_time | as_millis }}",
+                Results {
+                    wall_time: std::time::Duration::from_millis(12345),
+                    ..Results::default()
+                },
+                "millis: 12345",
+            );
+        }
     }
 }

--- a/src/measurement.rs
+++ b/src/measurement.rs
@@ -24,30 +24,24 @@ struct ProbeMeasurement {
 pub struct Results {
     /// Wall run time of process.
     pub wall_time: Duration,
-    /// Average CPU utilization percentage.
-    pub avg_cpu: f32,
-    /// Average RAM utilization in Bytes.
-    pub avg_ram: u64,
+    /// CPU utilization percentage.
+    pub cpu: Vec<f64>,
+    /// RAM utilization in Bytes.
+    pub ram: Vec<f64>,
 }
 
 impl Results {
     /// Perform necessary aggregations on the measurements to create final results.
     fn from_measurements(wall_time: Duration, measurements: Vec<ProbeMeasurement>) -> Self {
-        let probe_count = measurements.len();
-        let measurement_sums = measurements
-            .into_iter()
-            .reduce(|m1, m2| ProbeMeasurement {
-                cpu: m1.cpu + m2.cpu,
-                ram: m1.ram + m2.ram,
-            })
-            .unwrap();
         #[allow(clippy::cast_precision_loss)]
-        let avg_cpu = measurement_sums.cpu / probe_count as f32;
-        let avg_ram = measurement_sums.ram / probe_count as u64;
+        let (cpu, ram) = measurements
+            .into_iter()
+            .map(|ProbeMeasurement { cpu, ram }| (f64::from(cpu), ram as f64))
+            .collect();
         Self {
             wall_time,
-            avg_cpu,
-            avg_ram,
+            cpu,
+            ram,
         }
     }
 }


### PR DESCRIPTION
Activates builtin filters for Jinja templates (e.g. `min` and `max`),
and implements a few custom filters as well (`avg`, `as_kb`, `as_mb`, `as_millis`, `as_secs`)
for use in output templates.

Closed: #56
